### PR TITLE
Pass exit listener name to fix uncaught exception during shutdown.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,7 @@ function gelfAppender(layout, config, levels) {
   app.shutdown = function (cb) {
     debug('Shutdown called');
     client.close(cb);
-    process.removeListener(exit);
+    process.removeListener('exit', exit);
   };
 
   return app;


### PR DESCRIPTION
The following error occurs during shutdown of the appender on Node v8.11.2:
```
Uncaught exception occured! TypeError: "listener" argument must be a function
    at process.removeListener (events.js:359:15)
    at Function.app.shutdown (.../node_modules/@log4js-node/gelf/lib/index.js:136:13)
    at appendersToCheck.filter.forEach.a (.../node_modules/log4js/lib/log4js.js:107:59)
    at Array.forEach (<anonymous>)
    at Object.shutdown (.../node_modules/log4js/lib/log4js.js:107:44)
    at Timeout._onTimeout (.../gulpfile.js:565:16)
    at ontimeout (timers.js:498:11)
    at tryOnTimeout (timers.js:323:5)
    at Timer.listOnTimeout (timers.js:290:5)
Trying to close client connection here Socket {
  domain: null,
  _events: { close: [Function: complete] },
  _eventsCount: 1,
  _maxListeners: undefined,
  _handle: null,
  _receiving: false,
  _bindState: 2,
  type: 'udp4',
  fd: null,
  _reuseAddr: undefined,
  _queue: undefined,
  [Symbol(options symbol)]: {},
  [Symbol(asyncId)]: 62 }
Unhandled promise rejection! Error [ERR_SOCKET_DGRAM_NOT_RUNNING]: Not running
    at Socket._healthCheck (dgram.js:638:11)
    at Socket.close (dgram.js:516:8)
    at process.exit (.../node_modules/@log4js-node/gelf/lib/index.js:55:12)
    at emitOne (events.js:121:20)
    at process.emit (events.js:211:7)
    at process.exit (internal/process.js:157:15)
    at Logger.shutdown.then (.../logger.js:170:42)
    at <anonymous>
```